### PR TITLE
Disable SSL cert verification

### DIFF
--- a/lib/wsferb.rb
+++ b/lib/wsferb.rb
@@ -30,6 +30,7 @@ module WSFErb
 
   def self.client(options)
     Savon::Client.new do |wsdl, http|
+      http.auth.ssl.verify_mode = :none
       wsdl.document = options[:wsdl]
       wsdl.endpoint = test_mode_enabled? ? options[:testing_url] : options[:production_url]
     end


### PR DESCRIPTION
Esta modificación debería bastar para deshabilitar la verificación del certificado nuevo de AFIP.
